### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Seeed Studio
 maintainer=Seeed Studio <techsupport@seeed.cc>
 sentence=Arduino library to control Wio LTE Arduino Library.
 paragraph=Wio LTE is a board combined with STM32F405RGT6 and quectel EC21(4G/3G/GPS) module.
-category=Device
+category=Device Control
 url=https://github.com/Seeed-Studio/Wio_LTE_Arduino_Library
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Device' in library Wio LTE Arduino Library is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format